### PR TITLE
Install nanobot dependencies in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,9 +39,11 @@ COPY --link . .
 # Precompile bootsnap code for faster boot times
 RUN bundle exec bootsnap precompile app/ lib/
 
+# Nanobot Gemini AI dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends build-essential libffi-dev libsodium-dev lua5.4-dev curl
+
 # Precompiling assets for production without requiring secret RAILS_MASTER_KEY
 RUN SECRET_KEY_BASE_DUMMY=1 ./bin/rails assets:precompile
-
 
 # Final stage for app image
 FROM base


### PR DESCRIPTION
This is an attempt to fix issue with missing `sodium` package (I.e., packages related to Nanobots). I have low confidence in this passing, but perhaps there is a development issue that won't apply to deploy.