### PR TITLE
Reduce Fly VM memory

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -36,7 +36,7 @@ console_command = '/rails/bin/rails console'
       X-Forwarded-Proto = 'https'
 
 [[vm]]
-  memory = '1gb'
+  memory = '512mb'
   cpu_kind = 'shared'
   cpus = 1
 


### PR DESCRIPTION
This is to reduce cost of running this app, especially while developing it.