### PR TITLE
Add additional Capy specs for My Workouts 

### DIFF
--- a/app/views/exercise_sets/_form.html.erb
+++ b/app/views/exercise_sets/_form.html.erb
@@ -17,7 +17,7 @@
         </div>
         <div class="basis-1/5 md:basis-24">
             <%= f.label :weight, class: "font-bold" %><br />
-            <%= f.number_field :weight, class: "w-full h-8 py-0 px-1" %>
+            <%= f.number_field :weight, class: "w-full h-8 py-0 px-1", step: ".25" %>
         </div>
         <div class="">
             <%= f.label :weight_unit, "Wt. Unit", class: "font-bold" %><br />

--- a/lib/GeminiAssistant.rb
+++ b/lib/GeminiAssistant.rb
@@ -6,6 +6,8 @@ module GeminiAssistant
             workout = Workout.includes(:exercises).find_by(id: workout_id)
             exercises = workout.exercises
 
+            return "Please add exercises to this workout before evaluating it." if exercises.size == 0
+
             exercise_text = exercises.map {|exercise| "exercise name: #{exercise.name}, exercise description: #{exercise.description}"}.join(";")
 
             heredoc_text = <<-HEREDOC

--- a/spec/factories/exercise_sets.rb
+++ b/spec/factories/exercise_sets.rb
@@ -9,6 +9,6 @@ FactoryBot.define do
   end
 
   trait :with_weight do
-    weight { Faker::Number.decimal(l_digits: 2, r_digits: 2) }
+    weight { Faker::Number.number(digits: 3) }
   end
 end

--- a/spec/factories/exercise_sets.rb
+++ b/spec/factories/exercise_sets.rb
@@ -3,4 +3,12 @@ FactoryBot.define do
     weight_unit { "lbs" }
     exercise 
   end
+
+  trait :with_reps do
+    reps { Faker::Number.number(digits:2) }
+  end
+
+  trait :with_weight do
+    weight { Faker::Number.decimal(l_digits: 2, r_digits: 2) }
+  end
 end

--- a/spec/factories/exercises.rb
+++ b/spec/factories/exercises.rb
@@ -6,5 +6,15 @@ FactoryBot.define do
     trait :with_a_description do
       description { Faker::Lorem.sentence }
     end
+
+    trait :with_exercise_sets do 
+      transient do
+        exercise_set_traits { [] }
+      end
+
+      after :create do |exercise, evaluator|
+        exercise.exercise_sets = create_list :exercise_set, 3, *evaluator.exercise_set_traits, exercise: exercise
+      end
+    end
   end
 end

--- a/spec/features/my_workouts_spec.rb
+++ b/spec/features/my_workouts_spec.rb
@@ -146,4 +146,34 @@ RSpec.feature "MyWorkouts", type: :feature, js: true do
       }.to change { exercise.reload.gemini_response }.from(nil).to(evaluation_stub)
     end
   end
+
+  context "exercise sets" do
+    it "creates an exercise set for an existing exercise" do
+      exercise = create :exercise, :with_a_description
+
+      sign_in exercise.user
+
+      expect {
+        visit my_workouts_path
+  
+        expect(page).to have_button exercise.workout.date.strftime("%Y-%m-%d")
+        click_button exercise.workout.date.strftime("%Y-%m-%d")
+  
+        expect(page).to have_button exercise.name
+        click_button exercise.name
+  
+        expect(page).to have_content exercise.description
+  
+        reps = 10
+        weight = 120
+        within("form[action=\"#{workout_exercise_exercise_sets_path(exercise.workout, exercise)}\"") do
+          fill_in "exercise_set[reps]", with: reps
+          fill_in "exercise_set[weight]", with: weight
+        end
+  
+        click_button "Add Set"
+        expect(page).to have_content "Set: #{reps} reps, #{weight.to_f} lbs"
+      }.to change { ExerciseSet.count }.from(0).to(1)
+    end
+  end
 end

--- a/spec/features/my_workouts_spec.rb
+++ b/spec/features/my_workouts_spec.rb
@@ -67,6 +67,54 @@ RSpec.feature "MyWorkouts", type: :feature, js: true do
       expect(page).not_to have_content suggested_exercise_stub
       expect(page).not_to have_content "Selected Muscle Groups: #{muscle_groups.join(',')}"
     end
+
+    context "when there are exercises" do
+      it "provides a workout analysis" do
+        workout = create :workout, :with_exercises, user: user
+        workout_date_formatted = workout.date.strftime("%Y-%m-%d")
+
+        evaluation_stub_text = "This workout targeted the abs and legs."
+
+        expect(GeminiAssistant).to receive(:evaluate_workout).with(workout.id) { evaluation_stub_text }
+
+        visit my_workouts_path
+
+        expect(page).to have_button workout_date_formatted
+        click_button workout_date_formatted
+
+        expect(page).to have_button "Toggle Workout Analysis"
+        click_button "Toggle Workout Analysis"
+
+        expect(page).to have_link "Generate Workout Analysis"
+        click_link "Generate Workout Analysis"
+
+        expect(page).to have_content evaluation_stub_text
+      end
+    end
+
+    context "when there are not exercises" do
+      it "the workout cannot be analyzed" do
+        workout = create :workout, user: user
+        workout_date_formatted = workout.date.strftime("%Y-%m-%d")
+
+        evaluation_stub_text = "Please add exercises to this workout before evaluating it."
+
+        expect(GeminiAssistant).to receive(:evaluate_workout).with(workout.id) { evaluation_stub_text }
+
+        visit my_workouts_path
+
+        expect(page).to have_button workout_date_formatted
+        click_button workout_date_formatted
+
+        expect(page).to have_button "Toggle Workout Analysis"
+        click_button "Toggle Workout Analysis"
+
+        expect(page).to have_link "Generate Workout Analysis"
+        click_link "Generate Workout Analysis"
+
+        expect(page).to have_content evaluation_stub_text
+      end
+    end
   end
 
   context "exercises" do

--- a/spec/features/my_workouts_spec.rb
+++ b/spec/features/my_workouts_spec.rb
@@ -175,5 +175,53 @@ RSpec.feature "MyWorkouts", type: :feature, js: true do
         expect(page).to have_content "Set: #{reps} reps, #{weight.to_f} lbs"
       }.to change { ExerciseSet.count }.from(0).to(1)
     end
+
+    it "allows the user to edit an existing exercise set" do
+      exercise = create :exercise, :with_a_description, :with_exercise_sets, exercise_set_traits: [:with_reps, :with_weight]
+
+      sign_in exercise.user
+
+      visit my_workouts_path
+
+      workout_date_formatted = exercise.workout.date.strftime("%Y-%m-%d")
+      expect(page).to have_button 
+      click_button workout_date_formatted
+
+      expect(page).to have_button exercise.name
+      click_button exercise.name
+
+      # Wait for the exercise set index to be on the page, then scroll to it to trigger turbo loads on set info
+      expect(page).to have_selector "#exercise_sets_exercise_#{exercise.id}", visible: :all
+      scroll_to find("#exercise_sets_exercise_#{exercise.id}", visible: :all)
+      
+      # With the turbo frame in view, the set info will load into the page
+      exercise_set = exercise.exercise_sets.last
+      expect(page).to have_content "Set: #{exercise_set.reps} reps, #{exercise_set.weight.to_f} lbs"
+
+      # Open the edit form
+      expect(page).to have_link href: edit_workout_exercise_exercise_set_path(exercise.workout, exercise, exercise_set)
+      click_link href: edit_workout_exercise_exercise_set_path(exercise.workout, exercise, exercise_set)
+      
+      expect(page).to have_selector("#info_exercise_set_#{exercise_set.id}")
+
+      reps = 10
+      weight = 50.25
+      within find("#info_exercise_set_#{exercise_set.id}").find("form") do
+        rep_input_name = "exercise_set[reps]"
+        weight_input_name = "exercise_set[weight]"
+
+        expect(find("input[name=\"#{rep_input_name}\"").value).to eq exercise_set.reps.to_s
+        expect(find("input[name=\"#{weight_input_name}\"").value).to eq exercise_set.weight.to_s
+
+        fill_in rep_input_name, with: reps
+        fill_in weight_input_name, with: weight
+        
+        click_button "Update"
+      end
+
+      expect(page).to have_content "Set: #{reps} reps, #{weight.to_f} lbs"
+      expect(exercise_set.reload.reps).to eq reps
+      expect(exercise_set.reload.weight).to eq weight
+    end
   end
 end


### PR DESCRIPTION
- Prevent workouts without exercises from being evaluated by returning a hard coded string from `GeminiAssistant::evaluate_workout`
- Set `step` attribute for exercise set weight, in order to prevent arbitrary values from being entered initially and enforced on subsequent updates (e.g. initial weight of 124.27 would be limited for a .5 step to 123.77 and 124.77) 