### PR TITLE
Remove edit options from Everyone's Workouts page

### DIFF
--- a/app/controllers/exercises_controller.rb
+++ b/app/controllers/exercises_controller.rb
@@ -1,7 +1,7 @@
 include GeminiAssistant
 
 class ExercisesController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: [ :index, :show ]
   before_action :set_exercise, only: %i[ show edit update destroy ]
   before_action :set_workout
   before_action :check_author, except: [:index, :show]

--- a/app/views/exercise_sets/_exercise_set.html.erb
+++ b/app/views/exercise_sets/_exercise_set.html.erb
@@ -3,12 +3,14 @@
         <div class="flex gap-x-4">
             <p>Set: <%= "#{exercise_set.reps} reps" if exercise_set.reps %><%= ", " if exercise_set.reps && exercise_set.weight %><%= "#{exercise_set.weight} #{exercise_set.weight_unit}" if exercise_set.weight %> <%=  %></p>
 
-            <%= link_to edit_workout_exercise_exercise_set_path(workout, exercise, exercise_set) do %>
-                <i class="fa-solid fa-pencil"></i>
-            <% end %>
+            <% if current_user == workout.user && request.referrer == my_workouts_url %>
+                <%= link_to edit_workout_exercise_exercise_set_path(workout, exercise, exercise_set) do %>
+                    <i class="fa-solid fa-pencil"></i>
+                <% end %>
 
-            <%= button_to workout_exercise_exercise_set_path(workout, exercise, exercise_set), method: :delete, data: { turbo_confirm: "Are you sure?" } do %>
-                <i class="fa-regular fa-trash-can"></i>
+                <%= button_to workout_exercise_exercise_set_path(workout, exercise, exercise_set), method: :delete, data: { turbo_confirm: "Are you sure?" } do %>
+                    <i class="fa-regular fa-trash-can"></i>
+                <% end %>
             <% end %>
         </div>
     <% end %>

--- a/app/views/exercises/_exercise.html.erb
+++ b/app/views/exercises/_exercise.html.erb
@@ -1,5 +1,5 @@
 <div id="<%= dom_id exercise %>">
-  <% if current_user == workout.user %>
+  <% if current_user == workout.user && request.referrer == my_workouts_url %>
     <%= turbo_frame_tag dom_id(exercise, "exercise_set_form") do %>
       <%= render "exercise_sets/form", workout: workout, exercise: exercise, exercise_set: ExerciseSet.new %>
     <% end %>
@@ -20,7 +20,7 @@
     </p>
   <% end %>
 
-  <% if current_user == workout.user %>
+  <% if current_user == workout.user && request.referrer == my_workouts_url %>
     <%= link_to "Evaluate Exercise", workout_exercise_evaluate_exercise_path(workout, exercise), data: { turbo_frame: dom_id(exercise, "evaluation"), turbo_stream: true}, class: "btn-primary" %>
   <% end %>
 
@@ -33,15 +33,17 @@
     <%= render "loading_spinner" %>
   </div>
 
-  <div class="mb-4 mt-2">
-    <div>
-        <% unless true %>
-          <%= render "exercises/exercises_show_link", workout: workout, exercise: exercise %>
-        <% end %>
-        <% if current_user == workout.user %>
-          <%= render "exercises/exercises_edit_link", workout: workout, exercise: exercise %>
-          <%= render "exercises/exercises_destroy_link", workout: workout, exercise: exercise %>
-        <% end %>
+  <% if current_user == workout.user && request.referrer == my_workouts_url %>
+    <div class="mb-4 mt-2">
+      <div>
+          <% unless true %>
+            <%= render "exercises/exercises_show_link", workout: workout, exercise: exercise %>
+          <% end %>
+          <% if current_user == workout.user %>
+            <%= render "exercises/exercises_edit_link", workout: workout, exercise: exercise %>
+            <%= render "exercises/exercises_destroy_link", workout: workout, exercise: exercise %>
+          <% end %>
+      </div>
     </div>
-  </div>
+  <% end %>
 </div>

--- a/app/views/exercises/_exercise.html.erb
+++ b/app/views/exercises/_exercise.html.erb
@@ -13,12 +13,16 @@
     <%= exercise.name %>
   </p>
 
-  <p>
-    <span class="font-bold">Description:</span>
-    <%= exercise.description %>
-  </p>
+  <% if exercise.description.present? %>
+    <p>
+      <span class="font-bold">Description:</span>
+      <%= exercise.description %>
+    </p>
+  <% end %>
 
-  <%= link_to "Evaluate Exercise", workout_exercise_evaluate_exercise_path(workout, exercise), data: { turbo_frame: dom_id(exercise, "evaluation"), turbo_stream: true}, class: "btn-primary" %>
+  <% if current_user == workout.user %>
+    <%= link_to "Evaluate Exercise", workout_exercise_evaluate_exercise_path(workout, exercise), data: { turbo_frame: dom_id(exercise, "evaluation"), turbo_stream: true}, class: "btn-primary" %>
+  <% end %>
 
   <div>
     <%= turbo_frame_tag dom_id(exercise, "evaluation"), class: "[&[busy]]:blur-sm [&[busy]+div]:block" do %>

--- a/app/views/workouts/_workout.html.erb
+++ b/app/views/workouts/_workout.html.erb
@@ -30,10 +30,12 @@
         <% end %>    
     </div>
 
-    <div class="my-2">
-        <%= button_to workout, method: :delete, type: :button, data: { confirm: 'Are you sure?', turbo_confirm: "Are you sure?"}, class: "text-red-600 font-bold" do %>
-            <span class="">Delete Workout</span>
-            <i class="fa-regular fa-trash-can cursor-pointer"></i>
-        <% end %>
-    </div>
+    <% if current_user == workout.user && current_page?(my_workouts_path) %>
+        <div class="my-2">
+            <%= button_to workout, method: :delete, type: :button, data: { confirm: 'Are you sure?', turbo_confirm: "Are you sure?"}, class: "text-red-600 font-bold" do %>
+                <span class="">Delete Workout</span>
+                <i class="fa-regular fa-trash-can cursor-pointer"></i>
+            <% end %>
+        </div>
+    <% end %>
 </div>


### PR DESCRIPTION
- Remove edit options from Everyone's Workout's page (no unauthorized user could perform the edits due to controller hooks, but still these never should have been present to begin with)
  - Note: using `current_page?(my_workouts_path)` is unsuitable in the sub template views, since they check the current path based on the controller that renders the template. **The solution is to use `request.referrer`, which refers to the original url that made the request. **
- Fix `Content Missing` error by providing unauthenticated access for the exercises index action